### PR TITLE
Bump PHPMD to 2.7.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN $TARGET_DIR/composer-installer.sh && \
        "phpunit/phpunit:^8.0" \
        "phploc/phploc:^4.0" \
        "pdepend/pdepend:^2.5" \
-       "phpmd/phpmd:^2.6" \
+       "phpmd/phpmd:^2.7" \
        "sebastian/phpcpd:^2.0" \
        "friendsofphp/php-cs-fixer:^2.14" \
        "phpcompatibility/php-compatibility:^9.0" \


### PR DESCRIPTION
Hello @adamculp 

Thanks for presenting PHPMD in your YouTube video/webcast.

Not long after your video went online, a new team behind PHPMD was formed and at the end of July, we finally released PHPMD 2.7.0, containing all the new features, improvements and fixes from over 250 commits from two and a half years since 2.6.0.

https://github.com/phpmd/phpmd/releases/tag/2.7.0

Since, it keeps the PHP compatibility, I recommend not using anything below PHPMD 2.7.0 nowadays.

By the way, if you have any improvments, the new team behind PHPMD is happily accepting any issues/PRs from an active user as yours. :smirk: 